### PR TITLE
Fix long usernames/passwords failing due to newline in base64

### DIFF
--- a/jiralib2.el
+++ b/jiralib2.el
@@ -94,7 +94,7 @@
                              (read-passwd (format "Password or token for user %s: "
                                                   username)))))
           (cond ((member jiralib2-auth '(basic token))
-                 (base64-encode-string (format "%s:%s" username password)))
+                 (base64-encode-string (format "%s:%s" username password) t))
                 ((eq jiralib2-auth 'cookie)
                  (let* ((json-array-type jiralib2-json-array-type)
                         (reply-data


### PR DESCRIPTION
A long username or password causes `base64-encode-string` to add a line break by defauily. This in turn causes the following error: `user-error: Login denied: please login in the browser`.

Fixed it by disabling line breaking in `base64-encode-string`.