### PR TITLE
make more verbose session call errors

### DIFF
--- a/jiralib2.el
+++ b/jiralib2.el
@@ -167,6 +167,9 @@ Does not check for session validity."
                                                            jiralib2--session)))))
            :sync t
            :parser 'json-read
+           :error
+(cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                (message "Got error: %S %S" error-thrown args))) 
            args)))
 
 (defun jiralib2-session-call (path &rest args)


### PR DESCRIPTION
This has been lying around in my local copy from prior debugging sessions. I thought maybe it would be helpful to share a more verbose error during a session call.

Per usual, please feel free to nitpick away and thanks for your work on the library :)